### PR TITLE
Wu block

### DIFF
--- a/Configuration.json
+++ b/Configuration.json
@@ -38,6 +38,7 @@
   "CompressionType": "Maximum",
   "SelectiveRegistry": {
     "DisableWindowsUpdate": false,
+    "DisableWindowsUpdateMicrosoft": false,
     "DisableDriverUpdate": false,
     "DormantOneDrive": false
   }

--- a/Content/Additional/SelectiveRegistry/SelectiveRegistry.ps1
+++ b/Content/Additional/SelectiveRegistry/SelectiveRegistry.ps1
@@ -1,5 +1,5 @@
 RegHives -Load
-if($SelectiveRegistry.DisableWindowsUpdateCommunity -eq $true) {
+if($SelectiveRegistry.DisableWindowsUpdate -eq $true) {
 	Log $OptimizeData.SelectiveRegistryWindowsUpdate
 	RegKey -Path "HKLM:\WIM_HKLM_SOFTWARE\Microsoft\Windows\CurrentVersion\ContentDeliveryManager" -Name "SubscribedContent-310093Enabled" -Type DWord -Value 0
 	RegKey -Path "HKLM:\WIM_HKLM_SOFTWARE\Microsoft\Windows\CurrentVersion\DeliveryOptimization" -Name "SystemSettingsDownloadMode" -Type DWord -Value 0
@@ -16,15 +16,16 @@ if($SelectiveRegistry.DisableWindowsUpdateCommunity -eq $true) {
 	RegKey -Path "HKLM:\WIM_HKLM_SOFTWARE\Policies\Microsoft\Windows\WindowsUpdate\AU" -Name "AUOptions" -Type DWord -Value 2
 	RegKey -Path "HKLM:\WIM_HKLM_SOFTWARE\Policies\Microsoft\Windows\WindowsUpdate\AU" -Name "NoAutoUpdate" -Type DWord -Value 1
 	Start-Sleep 1
-	}
-if($SelectiveRegistry.DisableWindowsUpdateOEM -eq $true) {
+}
+if($SelectiveRegistry.DisableWindowsUpdateMicrosoft -eq $true) {
+	Log $OptimizeData.SelectiveRegistryWindowsUpdateMS
 	RegKey -Path "HKLM:\WIM_HKLM_SOFTWARE\Policies\Microsoft\Windows\WindowsUpdate" -Name "DoNotConnectToWindowsUpdateInternetLocations" -Type DWord -Value 1
 	RegKey -Path "HKLM:\WIM_HKLM_SOFTWARE\Policies\Microsoft\Windows\WindowsUpdate" -Name "DisableWindowsUpdateAccess" -Type DWord -Value 1
 	RegKey -Path "HKLM:\WIM_HKLM_SOFTWARE\Policies\Microsoft\Windows\WindowsUpdate" -Name "WUServer" -Type String -Value " "
 	RegKey -Path "HKLM:\WIM_HKLM_SOFTWARE\Policies\Microsoft\Windows\WindowsUpdate" -Name "WUStatusServer" -Type String -Value " "
 	RegKey -Path "HKLM:\WIM_HKLM_SOFTWARE\Policies\Microsoft\Windows\WindowsUpdate" -Name "UpdateServiceUrlAlternate" -Type String -Value " "
 	RegKey -Path "HKLM:\WIM_HKLM_SOFTWARE\Policies\Microsoft\Windows\WindowsUpdate\AU" -Name "UseWUServer" -Type DWord -Value 1
-Start-Sleep 1
+	Start-Sleep 1
 }
 
 if($SelectiveRegistry.DisableDriverUpdate -eq $true) {

--- a/Content/Additional/SelectiveRegistry/SelectiveRegistry.ps1
+++ b/Content/Additional/SelectiveRegistry/SelectiveRegistry.ps1
@@ -15,7 +15,36 @@ if($SelectiveRegistry.DisableWindowsUpdate -eq $true) {
 	RegKey -Path "HKLM:\WIM_HKLM_SOFTWARE\Policies\Microsoft\Windows\DeliveryOptimization" -Name "DODownloadMode" -Type DWord -Value 0
 	RegKey -Path "HKLM:\WIM_HKLM_SOFTWARE\Policies\Microsoft\Windows\WindowsUpdate\AU" -Name "AUOptions" -Type DWord -Value 2
 	RegKey -Path "HKLM:\WIM_HKLM_SOFTWARE\Policies\Microsoft\Windows\WindowsUpdate\AU" -Name "NoAutoUpdate" -Type DWord -Value 1
-	Start-Sleep 1
+	# https://docs.microsoft.com/en-us/windows/privacy/manage-connections-from-windows-operating-system-components-to-microsoft-services#29-windows-update	
+# Add a REG_DWORD value named DoNotConnectToWindowsUpdateInternetLocations to 
+# HKEY_LOCAL_MACHINE        \Software\Policies\Microsoft\Windows\WindowsUpdate        and set the value to 1.        
+RegKey -Path "HKLM:\WIM_HKLM_SOFTWARE\Policies\Microsoft\Windows\WindowsUpdate" -Name "DoNotConnectToWindowsUpdateInternetLocations" -Type DWord -Value 1
+#-and-
+
+#Add a REG_DWORD value named DisableWindowsUpdateAccess to 
+#HKEY_LOCAL_MACHINE          \Software\Policies\Microsoft\Windows\WindowsUpdate        and set the value to 1.
+RegKey -Path "HKLM:\WIM_HKLM_SOFTWARE\Policies\Microsoft\Windows\WindowsUpdate" -Name "DisableWindowsUpdateAccess" -Type DWord -Value 1
+#-and-
+
+#Add a REG_SZ value named WUServer to 
+# HKEY_LOCAL_MACHINE        \Software\Policies\Microsoft\Windows\WindowsUpdate         and ensure it is blank with a space character " ".
+RegKey -Path "HKLM:\WIM_HKLM_SOFTWARE\Policies\Microsoft\Windows\WindowsUpdate" -Name "WUServer" -Type String -Value " "
+#-and-
+
+#Add a REG_SZ value named WUStatusServer to 
+# HKEY_LOCAL_MACHINE        \Software\Policies\Microsoft\Windows\WindowsUpdate and ensure it is blank with a space character " ".
+RegKey -Path "HKLM:\WIM_HKLM_SOFTWARE\Policies\Microsoft\Windows\WindowsUpdate" -Name "WUStatusServer" -Type String -Value " "
+#-and-
+
+#Add a REG_SZ value named UpdateServiceUrlAlternate to 
+#HKEY_LOCAL_MACHINE         \Software\Policies\Microsoft\Windows\WindowsUpdate and ensure it is blank with a space character " ".
+RegKey -Path "HKLM:\WIM_HKLM_SOFTWARE\Policies\Microsoft\Windows\WindowsUpdate" -Name "UpdateServiceUrlAlternate" -Type String -Value " "
+#-and-
+
+#Add a REG_DWORD value named UseWUServer to 
+#HKEY_LOCAL_MACHINE         \Software\Policies\Microsoft\Windows\WindowsUpdate\AU and set the value to 1 (one).
+RegKey -Path "HKLM:\WIM_HKLM_SOFTWARE\Policies\Microsoft\Windows\WindowsUpdate\AU" -Name "UseWUServer" -Type DWord -Value 1
+Start-Sleep 1
 }
 
 if($SelectiveRegistry.DisableDriverUpdate -eq $true) {

--- a/Content/Additional/SelectiveRegistry/SelectiveRegistry.ps1
+++ b/Content/Additional/SelectiveRegistry/SelectiveRegistry.ps1
@@ -1,5 +1,5 @@
 RegHives -Load
-if($SelectiveRegistry.DisableWindowsUpdate -eq $true) {
+if($SelectiveRegistry.DisableWindowsUpdateCommunity -eq $true) {
 	Log $OptimizeData.SelectiveRegistryWindowsUpdate
 	RegKey -Path "HKLM:\WIM_HKLM_SOFTWARE\Microsoft\Windows\CurrentVersion\ContentDeliveryManager" -Name "SubscribedContent-310093Enabled" -Type DWord -Value 0
 	RegKey -Path "HKLM:\WIM_HKLM_SOFTWARE\Microsoft\Windows\CurrentVersion\DeliveryOptimization" -Name "SystemSettingsDownloadMode" -Type DWord -Value 0
@@ -15,35 +15,15 @@ if($SelectiveRegistry.DisableWindowsUpdate -eq $true) {
 	RegKey -Path "HKLM:\WIM_HKLM_SOFTWARE\Policies\Microsoft\Windows\DeliveryOptimization" -Name "DODownloadMode" -Type DWord -Value 0
 	RegKey -Path "HKLM:\WIM_HKLM_SOFTWARE\Policies\Microsoft\Windows\WindowsUpdate\AU" -Name "AUOptions" -Type DWord -Value 2
 	RegKey -Path "HKLM:\WIM_HKLM_SOFTWARE\Policies\Microsoft\Windows\WindowsUpdate\AU" -Name "NoAutoUpdate" -Type DWord -Value 1
-	# https://docs.microsoft.com/en-us/windows/privacy/manage-connections-from-windows-operating-system-components-to-microsoft-services#29-windows-update	
-# Add a REG_DWORD value named DoNotConnectToWindowsUpdateInternetLocations to 
-# HKEY_LOCAL_MACHINE        \Software\Policies\Microsoft\Windows\WindowsUpdate        and set the value to 1.        
-RegKey -Path "HKLM:\WIM_HKLM_SOFTWARE\Policies\Microsoft\Windows\WindowsUpdate" -Name "DoNotConnectToWindowsUpdateInternetLocations" -Type DWord -Value 1
-#-and-
-
-#Add a REG_DWORD value named DisableWindowsUpdateAccess to 
-#HKEY_LOCAL_MACHINE          \Software\Policies\Microsoft\Windows\WindowsUpdate        and set the value to 1.
-RegKey -Path "HKLM:\WIM_HKLM_SOFTWARE\Policies\Microsoft\Windows\WindowsUpdate" -Name "DisableWindowsUpdateAccess" -Type DWord -Value 1
-#-and-
-
-#Add a REG_SZ value named WUServer to 
-# HKEY_LOCAL_MACHINE        \Software\Policies\Microsoft\Windows\WindowsUpdate         and ensure it is blank with a space character " ".
-RegKey -Path "HKLM:\WIM_HKLM_SOFTWARE\Policies\Microsoft\Windows\WindowsUpdate" -Name "WUServer" -Type String -Value " "
-#-and-
-
-#Add a REG_SZ value named WUStatusServer to 
-# HKEY_LOCAL_MACHINE        \Software\Policies\Microsoft\Windows\WindowsUpdate and ensure it is blank with a space character " ".
-RegKey -Path "HKLM:\WIM_HKLM_SOFTWARE\Policies\Microsoft\Windows\WindowsUpdate" -Name "WUStatusServer" -Type String -Value " "
-#-and-
-
-#Add a REG_SZ value named UpdateServiceUrlAlternate to 
-#HKEY_LOCAL_MACHINE         \Software\Policies\Microsoft\Windows\WindowsUpdate and ensure it is blank with a space character " ".
-RegKey -Path "HKLM:\WIM_HKLM_SOFTWARE\Policies\Microsoft\Windows\WindowsUpdate" -Name "UpdateServiceUrlAlternate" -Type String -Value " "
-#-and-
-
-#Add a REG_DWORD value named UseWUServer to 
-#HKEY_LOCAL_MACHINE         \Software\Policies\Microsoft\Windows\WindowsUpdate\AU and set the value to 1 (one).
-RegKey -Path "HKLM:\WIM_HKLM_SOFTWARE\Policies\Microsoft\Windows\WindowsUpdate\AU" -Name "UseWUServer" -Type DWord -Value 1
+	Start-Sleep 1
+	}
+if($SelectiveRegistry.DisableWindowsUpdateOEM -eq $true) {
+	RegKey -Path "HKLM:\WIM_HKLM_SOFTWARE\Policies\Microsoft\Windows\WindowsUpdate" -Name "DoNotConnectToWindowsUpdateInternetLocations" -Type DWord -Value 1
+	RegKey -Path "HKLM:\WIM_HKLM_SOFTWARE\Policies\Microsoft\Windows\WindowsUpdate" -Name "DisableWindowsUpdateAccess" -Type DWord -Value 1
+	RegKey -Path "HKLM:\WIM_HKLM_SOFTWARE\Policies\Microsoft\Windows\WindowsUpdate" -Name "WUServer" -Type String -Value " "
+	RegKey -Path "HKLM:\WIM_HKLM_SOFTWARE\Policies\Microsoft\Windows\WindowsUpdate" -Name "WUStatusServer" -Type String -Value " "
+	RegKey -Path "HKLM:\WIM_HKLM_SOFTWARE\Policies\Microsoft\Windows\WindowsUpdate" -Name "UpdateServiceUrlAlternate" -Type String -Value " "
+	RegKey -Path "HKLM:\WIM_HKLM_SOFTWARE\Policies\Microsoft\Windows\WindowsUpdate\AU" -Name "UseWUServer" -Type DWord -Value 1
 Start-Sleep 1
 }
 

--- a/en-US/Optimize-Offline.strings.psd1
+++ b/en-US/Optimize-Offline.strings.psd1
@@ -103,6 +103,7 @@ OptimizationsCompleted                  = {0} completed in [{1}] minutes with [{
 TerminatingOptimizations                = Discarding any Images and Terminating Optimizations.
 Populating                              = populating
 SelectiveRegistryWindowsUpdate          = Disabling Windows Update
+SelectiveRegistryWindowsUpdateMS        = Disabling Windows Update using Microsoft's Method
 SelectiveRegistryDriverUpdate           = Disabling automatic driver update
 SelectiveRegistryDormantOneDrive        = Enabling dormant OneDrive fix
 ServiceStartBoot 								 = Boot


### PR DESCRIPTION
Add an option to use the Microsoft approved registry changes to Disable Windows Update

It works:
It's what Microsoft offer as a solution to corporate clients, so it's meant to work.
I have tested using this change and restoring both online and as part of Optimize Offline

Restoring:
It's easy to restore windows update online. It only requires a single line of code
Get-Item "HKLM:\SOFTWARE\Policies\Microsoft\Windows\WindowsUpdate" | Remove-Item -Recurse -Force

Resource:
Microsoft states "You can turn off Windows Update by setting the following registry entries:" https://docs.microsoft.com/en-us/windows/privacy/manage-connections-from-windows-operating-system-components-to-microsoft-services#29-windows-update

PS:
I had a look at the presently used WU Block and googled the registry changes. It's really a mixed bag of stuff. TBH, I never used it, but I assume it works? Some of the changes block things that are very outdated now.